### PR TITLE
fix fullscreening on windows

### DIFF
--- a/src/modules/top_bar/default/top_bar.gd
+++ b/src/modules/top_bar/default/top_bar.gd
@@ -58,10 +58,9 @@ func _on_minimize_button_pressed() -> void:
 func _on_switch_mode_button_pressed() -> void:
 	match get_window().mode:
 		Window.MODE_WINDOWED:  
-			get_window().set_mode(Window.MODE_MAXIMIZED)
-			var screen_size := DisplayServer.screen_get_size()
-			get_window().size = screen_size - Vector2i(600,600)
-		Window.MODE_MAXIMIZED: get_window().set_mode(Window.MODE_WINDOWED)
+			get_window().set_mode(Window.MODE_FULLSCREEN)
+		Window.MODE_FULLSCREEN : 
+			get_window().set_mode(Window.MODE_WINDOWED)
 	Globals._on_window_mode_switch.emit()
 
 

--- a/src/project.godot
+++ b/src/project.godot
@@ -30,9 +30,6 @@ ProjectManager="*res://autoload/project_manager.gd"
 
 [display]
 
-window/size/viewport_width=1920
-window/size/viewport_height=1080
-window/size/mode=2
 window/size/borderless=true
 
 [gui]


### PR DESCRIPTION
I decided to open a pull request because of #36 .
I'm not sure how this impacts usability on Linux with a tiling WM but it temporarily fixes both gozen opening with a too big window (by reseting the startup size to the godot default) and maximizing the window until it gets properly fixed in the godot engine itself.
current limitation of this fix is that its fullscreening gozen instead of maximizing.